### PR TITLE
Note for the incompatibility for having Datadog Java Tracer and Jenkins plugin

### DIFF
--- a/docs/pipelines/jenkins.md
+++ b/docs/pipelines/jenkins.md
@@ -60,6 +60,8 @@ INFO    datadog.trace.core.StatusLogger#logStatus: DATADOG TRACER CONFIGURATION 
 
 Now you can use your Jenkins as you normally do.
 
+**Note**: It's not allowed to enable traces collection in the Jenkins Datadog plugin and have the `dd-java-agent` in the classpath (for example, as `-javaagent` in your Jenkins startup command) at the same time.
+
 ### Connecting Logs and Traces
 
 If you are already collecting logs in your Jenkins before enabling the traces collection, you don't need to perform additional actions.

--- a/docs/pipelines/jenkins.md
+++ b/docs/pipelines/jenkins.md
@@ -60,7 +60,7 @@ INFO    datadog.trace.core.StatusLogger#logStatus: DATADOG TRACER CONFIGURATION 
 
 Now you can use your Jenkins as you normally do.
 
-**Note**: It's not allowed to enable traces collection in the Jenkins Datadog plugin and have the `dd-java-agent` in the classpath (for example, as `-javaagent` in your Jenkins startup command) at the same time.
+**Note**: Please notice that it is not possible to enable traces collection in the Jenkins Datadog plugin and have the `dd-java-agent` in the classpath (for example, as `-javaagent` in your Jenkins startup command) at the same time.
 
 ### Connecting Logs and Traces
 


### PR DESCRIPTION
In this PR, we add the note about incompatibility for having Datadog Java Tracer and Jenkins plugin at the same time